### PR TITLE
feat(ui): inline quantity editing + ESC cancel; widen tap area

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -14,6 +14,7 @@ class YataApp extends ConsumerWidget {
     title: AppStrings.titleApp,
     theme: AppTheme.lightTheme,
     darkTheme: AppTheme.darkTheme,
+    themeMode: ThemeMode.light,
     routerConfig: AppRouter.getRouter(ref),
     debugShowCheckedModeBanner: false,
   );

--- a/lib/shared/components/inputs/quantity_stepper.dart
+++ b/lib/shared/components/inputs/quantity_stepper.dart
@@ -79,6 +79,13 @@ class _YataQuantityStepperState extends State<YataQuantityStepper> {
     if (mounted) setState(() => _editing = false);
   }
 
+  void _cancelEdit() {
+    if (!_editing) return;
+    _controller.text = widget.value.toString();
+    _focusNode.unfocus();
+    if (mounted) setState(() => _editing = false);
+  }
+
   @override
   void dispose() {
     _controller.dispose();
@@ -126,27 +133,42 @@ class _YataQuantityStepperState extends State<YataQuantityStepper> {
             child: _editing
                 ? SizedBox(
                     width: (widget.compact ? 36 : 48),
-                    child: Focus(
-                      onFocusChange: (bool hasFocus) {
-                        if (!hasFocus) _commitEdit();
+                    child: Shortcuts(
+                      shortcuts: <ShortcutActivator, Intent>{
+                        SingleActivator(LogicalKeyboardKey.escape): const _CancelEditIntent(),
                       },
-                      child: TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        autofocus: true,
-                        textAlign: TextAlign.center,
-                        style: valueStyle,
-                        keyboardType: TextInputType.number,
-                        inputFormatters: <TextInputFormatter>[
-                          FilteringTextInputFormatter.digitsOnly,
-                        ],
-                        onSubmitted: (_) => _commitEdit(),
-                        decoration: const InputDecoration(
-                          isDense: true,
-                          border: InputBorder.none,
-                          focusedBorder: InputBorder.none,
-                          enabledBorder: InputBorder.none,
-                          contentPadding: EdgeInsets.zero,
+                      child: Actions(
+                        actions: <Type, Action<Intent>>{
+                          _CancelEditIntent: CallbackAction<_CancelEditIntent>(
+                            onInvoke: (_CancelEditIntent intent) {
+                              _cancelEdit();
+                              return null;
+                            },
+                          ),
+                        },
+                        child: Focus(
+                          onFocusChange: (bool hasFocus) {
+                            if (!hasFocus) _commitEdit();
+                          },
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            autofocus: true,
+                            textAlign: TextAlign.center,
+                            style: valueStyle,
+                            keyboardType: TextInputType.number,
+                            inputFormatters: <TextInputFormatter>[
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
+                            onSubmitted: (_) => _commitEdit(),
+                            decoration: const InputDecoration(
+                              isDense: true,
+                              border: InputBorder.none,
+                              focusedBorder: InputBorder.none,
+                              enabledBorder: InputBorder.none,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -214,4 +236,8 @@ class _StepButton extends StatelessWidget {
       ),
     ),
   );
+}
+
+class _CancelEditIntent extends Intent {
+  const _CancelEditIntent();
 }

--- a/lib/shared/components/inputs/quantity_stepper.dart
+++ b/lib/shared/components/inputs/quantity_stepper.dart
@@ -129,10 +129,10 @@ class _YataQuantityStepperState extends State<YataQuantityStepper> {
             compact: widget.compact,
           ),
           ConstrainedBox(
-            constraints: BoxConstraints(minWidth: widget.compact ? 22 : 28),
+            constraints: BoxConstraints(minWidth: widget.compact ? 28 : 36),
             child: _editing
                 ? SizedBox(
-                    width: (widget.compact ? 36 : 48),
+                    width: (widget.compact ? 42 : 56),
                     child: Shortcuts(
                       shortcuts: <ShortcutActivator, Intent>{
                         SingleActivator(LogicalKeyboardKey.escape): const _CancelEditIntent(),

--- a/lib/shared/components/inputs/quantity_stepper.dart
+++ b/lib/shared/components/inputs/quantity_stepper.dart
@@ -5,10 +5,10 @@ import "../../foundations/tokens/color_tokens.dart";
 import "../../foundations/tokens/radius_tokens.dart";
 import "../../foundations/tokens/spacing_tokens.dart";
 import "../../foundations/tokens/typography_tokens.dart";
-import "../../themes/app_theme.dart";
+// Dialog-free inline editing does not need app theme import
 
 /// 数量の増減を行うステッパー。
-class YataQuantityStepper extends StatelessWidget {
+class YataQuantityStepper extends StatefulWidget {
   /// [YataQuantityStepper]を生成する。
   const YataQuantityStepper({
     required this.value,
@@ -34,87 +34,63 @@ class YataQuantityStepper extends StatelessWidget {
   /// コンパクト表示にするかどうか。
   final bool compact;
 
-  bool get _canDecrement => value > min;
+  @override
+  State<YataQuantityStepper> createState() => _YataQuantityStepperState();
+}
 
-  bool get _canIncrement => max == null || value < max!;
+class _YataQuantityStepperState extends State<YataQuantityStepper> {
+  bool _editing = false;
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.value.toString(),
+  );
+  final FocusNode _focusNode = FocusNode();
+
+  bool get _canDecrement => widget.value > widget.min;
+  bool get _canIncrement => widget.max == null || widget.value < widget.max!;
 
   int _clampQuantity(int q) {
-    if (q < min) return min;
-    if (max != null && q > max!) return max!;
+    if (q < widget.min) return widget.min;
+    if (widget.max != null && q > widget.max!) return widget.max!;
     return q;
   }
 
-  Future<void> _promptForValue(BuildContext context) async {
-    final TextEditingController controller = TextEditingController(text: "$value");
-    int? result;
-
-    Future<void> submit() async {
-      final int? parsed = int.tryParse(controller.text.trim());
-      if (parsed == null) {
-        Navigator.of(context).pop();
-        return;
+  void _beginEdit() {
+    setState(() {
+      _editing = true;
+      _controller.text = widget.value.toString();
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _focusNode.requestFocus();
+        _controller.selection = TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
       }
-      result = _clampQuantity(parsed);
-      Navigator.of(context).pop();
+    });
+  }
+
+  void _commitEdit() {
+    if (!_editing) return;
+    final int? parsed = int.tryParse(_controller.text.trim());
+    if (parsed == null) {
+      _controller.text = widget.value.toString();
+    } else {
+      final int clamped = _clampQuantity(parsed);
+      if (clamped != widget.value) widget.onChanged(clamped);
     }
+    if (mounted) setState(() => _editing = false);
+  }
 
-    await showDialog<void>(
-      context: context,
-      builder: (BuildContext ctx) {
-        final ThemeData theme = Theme.of(ctx);
-        final ColorScheme scheme = theme.colorScheme;
-        final TextStyle titleStyle =
-            (theme.textTheme.headlineSmall ?? YataTypographyTokens.headlineSmall).copyWith(
-              color: scheme.onSurface,
-            );
-        final TextStyle inputTextStyle =
-            (theme.textTheme.titleLarge ?? YataTypographyTokens.titleLarge).copyWith(
-              color: scheme.onSurface,
-            );
-        final TextStyle hintStyle = (theme.textTheme.bodyMedium ?? YataTypographyTokens.bodyMedium)
-            .copyWith(color: scheme.onSurfaceVariant);
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
 
-        return Theme(
-          data: AppTheme.lightTheme,
-          child: Builder(
-            builder: (BuildContext lightCtx) {
-              final ColorScheme lightScheme = Theme.of(lightCtx).colorScheme;
-              return AlertDialog(
-                backgroundColor: lightScheme.surface,
-                surfaceTintColor: Colors.transparent,
-                title: Text("数量を入力", style: titleStyle.copyWith(color: lightScheme.onSurface)),
-                content: TextField(
-                  controller: controller,
-                  autofocus: true,
-                  textAlign: TextAlign.center,
-                  style: inputTextStyle.copyWith(color: lightScheme.onSurface),
-                  cursorColor: lightScheme.primary,
-                  keyboardType: TextInputType.number,
-                  inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-                  onSubmitted: (_) => submit(),
-                  decoration: InputDecoration(
-                    hintText: "$min${max != null ? " ~ ${max!}" : "以上"}",
-                    hintStyle: hintStyle.copyWith(color: lightScheme.onSurfaceVariant),
-                    filled: true,
-                    fillColor: lightScheme.surface,
-                  ),
-                ),
-                actions: <Widget>[
-                  TextButton(
-                    onPressed: () => Navigator.of(lightCtx).pop(),
-                    child: const Text("キャンセル"),
-                  ),
-                  FilledButton(onPressed: submit, child: const Text("OK")),
-                ],
-              );
-            },
-          ),
-        );
-      },
-    );
-
-    if (result != null && result != value) {
-      onChanged(result!);
+  @override
+  void didUpdateWidget(covariant YataQuantityStepper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_editing && oldWidget.value != widget.value) {
+      _controller.text = widget.value.toString();
     }
   }
 
@@ -138,38 +114,70 @@ class YataQuantityStepper extends StatelessWidget {
             icon: Icons.remove,
             enabled: _canDecrement,
             onPressed: () {
+              if (_editing) _commitEdit();
               if (_canDecrement) {
-                onChanged(value - 1);
+                widget.onChanged(widget.value - 1);
               }
             },
-            compact: compact,
+            compact: widget.compact,
           ),
           ConstrainedBox(
-            constraints: BoxConstraints(minWidth: compact ? 22 : 28),
-            child: Material(
-              type: MaterialType.transparency,
-              child: InkWell(
-                onTap: () => _promptForValue(context),
-                borderRadius: const BorderRadius.all(Radius.circular(YataRadiusTokens.medium)),
-                child: Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: compact ? YataSpacingTokens.sm : YataSpacingTokens.md,
+            constraints: BoxConstraints(minWidth: widget.compact ? 22 : 28),
+            child: _editing
+                ? SizedBox(
+                    width: (widget.compact ? 36 : 48),
+                    child: Focus(
+                      onFocusChange: (bool hasFocus) {
+                        if (!hasFocus) _commitEdit();
+                      },
+                      child: TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        autofocus: true,
+                        textAlign: TextAlign.center,
+                        style: valueStyle,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: <TextInputFormatter>[
+                          FilteringTextInputFormatter.digitsOnly,
+                        ],
+                        onSubmitted: (_) => _commitEdit(),
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          border: InputBorder.none,
+                          focusedBorder: InputBorder.none,
+                          enabledBorder: InputBorder.none,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                      ),
+                    ),
+                  )
+                : Material(
+                    type: MaterialType.transparency,
+                    child: InkWell(
+                      onTap: _beginEdit,
+                      borderRadius: const BorderRadius.all(
+                        Radius.circular(YataRadiusTokens.medium),
+                      ),
+                      child: Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: widget.compact ? YataSpacingTokens.sm : YataSpacingTokens.md,
+                        ),
+                        alignment: Alignment.center,
+                        child: Text("${widget.value}", style: valueStyle),
+                      ),
+                    ),
                   ),
-                  alignment: Alignment.center,
-                  child: Text("$value", style: valueStyle),
-                ),
-              ),
-            ),
           ),
           _StepButton(
             icon: Icons.add,
             enabled: _canIncrement,
             onPressed: () {
+              if (_editing) _commitEdit();
               if (_canIncrement) {
-                onChanged(value + 1);
+                widget.onChanged(widget.value + 1);
               }
             },
-            compact: compact,
+            compact: widget.compact,
           ),
         ],
       ),

--- a/lib/shared/foundations/tokens/elevetion_token.dart
+++ b/lib/shared/foundations/tokens/elevetion_token.dart
@@ -5,9 +5,7 @@ class YataElevationTokens {
   const YataElevationTokens._();
 
   /// フラットな状態。影なし。
-  static const List<BoxShadow> level0 = <BoxShadow>[
-    BoxShadow(color: Colors.transparent),
-  ];
+  static const List<BoxShadow> level0 = <BoxShadow>[BoxShadow(color: Colors.transparent)];
 
   /// カードやリストで使用する最小の影。
   static const List<BoxShadow> level1 = <BoxShadow>[

--- a/lib/shared/themes/app_theme.dart
+++ b/lib/shared/themes/app_theme.dart
@@ -95,17 +95,17 @@ class AppTheme {
   }
 
   static AppBarTheme _buildAppBarTheme(ColorScheme colorScheme) => AppBarTheme(
-      backgroundColor: colorScheme.surface,
-      surfaceTintColor: Colors.transparent,
-      elevation: 0,
-      scrolledUnderElevation: 0,
-      centerTitle: false,
-      foregroundColor: colorScheme.onSurface,
-      titleTextStyle: GoogleFonts.notoSansJp(
-        textStyle: YataTypographyTokens.titleLarge.copyWith(color: colorScheme.onSurface),
-      ),
-      iconTheme: IconThemeData(color: colorScheme.onSurfaceVariant),
-    );
+    backgroundColor: colorScheme.surface,
+    surfaceTintColor: Colors.transparent,
+    elevation: 0,
+    scrolledUnderElevation: 0,
+    centerTitle: false,
+    foregroundColor: colorScheme.onSurface,
+    titleTextStyle: GoogleFonts.notoSansJp(
+      textStyle: YataTypographyTokens.titleLarge.copyWith(color: colorScheme.onSurface),
+    ),
+    iconTheme: IconThemeData(color: colorScheme.onSurfaceVariant),
+  );
 
   static CardThemeData _buildCardTheme(ColorScheme colorScheme) {
     final BoxShadow cardShadow = YataElevationTokens.level1.first;
@@ -123,7 +123,8 @@ class AppTheme {
     );
   }
 
-  static FilledButtonThemeData _buildFilledButtonTheme(ColorScheme colorScheme) => FilledButtonThemeData(style: _buildPrimaryFilledButtonStyle(colorScheme));
+  static FilledButtonThemeData _buildFilledButtonTheme(ColorScheme colorScheme) =>
+      FilledButtonThemeData(style: _buildPrimaryFilledButtonStyle(colorScheme));
 
   static ButtonStyle _buildPrimaryFilledButtonStyle(ColorScheme colorScheme) {
     final BoxShadow buttonShadow = YataElevationTokens.level2.first;
@@ -146,96 +147,98 @@ class AppTheme {
     );
   }
 
-  static ElevatedButtonThemeData _buildElevatedButtonTheme(ColorScheme colorScheme) => ElevatedButtonThemeData(
-      style: _buildPrimaryFilledButtonStyle(colorScheme).copyWith(
-        backgroundColor: WidgetStateProperty.resolveWith(
-          (Set<WidgetState> states) => states.contains(WidgetState.disabled)
-              ? colorScheme.primary.withOpacity(0.45)
-              : colorScheme.primary,
-        ),
-        foregroundColor: WidgetStateProperty.resolveWith(
-          (Set<WidgetState> states) => states.contains(WidgetState.disabled)
-              ? colorScheme.onSurface.withOpacity(0.4)
-              : colorScheme.onPrimary,
-        ),
-        overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-          if (states.contains(WidgetState.disabled)) {
-            return Colors.transparent;
-          }
-          if (states.contains(WidgetState.pressed)) {
-            return colorScheme.primary.withOpacity(0.18);
-          }
-          if (states.contains(WidgetState.hovered)) {
-            return colorScheme.primary.withOpacity(0.1);
-          }
-          return null;
-        }),
-      ),
-    );
-
-  static OutlinedButtonThemeData _buildOutlinedButtonTheme(ColorScheme colorScheme) => OutlinedButtonThemeData(
-      style: ButtonStyle(
-        foregroundColor: WidgetStateProperty.resolveWith(
-          (Set<WidgetState> states) => states.contains(WidgetState.disabled)
-              ? colorScheme.onSurface.withOpacity(0.4)
-              : colorScheme.primary,
-        ),
-        textStyle: WidgetStateProperty.all(
-          YataTypographyTokens.labelLarge.copyWith(color: colorScheme.primary),
-        ),
-        padding: WidgetStateProperty.all(
-          const EdgeInsets.symmetric(
-            horizontal: YataSpacingTokens.lg,
-            vertical: YataSpacingTokens.sm,
-          ),
-        ),
-        shape: WidgetStateProperty.all(
-          const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.medium)),
-          ),
-        ),
-        side: WidgetStateProperty.resolveWith(
-          (Set<WidgetState> states) => BorderSide(
-            color: states.contains(WidgetState.disabled)
-                ? colorScheme.outlineVariant
+  static ElevatedButtonThemeData _buildElevatedButtonTheme(ColorScheme colorScheme) =>
+      ElevatedButtonThemeData(
+        style: _buildPrimaryFilledButtonStyle(colorScheme).copyWith(
+          backgroundColor: WidgetStateProperty.resolveWith(
+            (Set<WidgetState> states) => states.contains(WidgetState.disabled)
+                ? colorScheme.primary.withOpacity(0.45)
                 : colorScheme.primary,
           ),
+          foregroundColor: WidgetStateProperty.resolveWith(
+            (Set<WidgetState> states) => states.contains(WidgetState.disabled)
+                ? colorScheme.onSurface.withOpacity(0.4)
+                : colorScheme.onPrimary,
+          ),
+          overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+            if (states.contains(WidgetState.disabled)) {
+              return Colors.transparent;
+            }
+            if (states.contains(WidgetState.pressed)) {
+              return colorScheme.primary.withOpacity(0.18);
+            }
+            if (states.contains(WidgetState.hovered)) {
+              return colorScheme.primary.withOpacity(0.1);
+            }
+            return null;
+          }),
         ),
-        overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-          if (states.contains(WidgetState.disabled)) {
-            return Colors.transparent;
-          }
-          final double opacity = states.contains(WidgetState.pressed) ? 0.1 : 0.05;
-          return colorScheme.primary.withOpacity(opacity);
-        }),
-      ),
-    );
+      );
+
+  static OutlinedButtonThemeData _buildOutlinedButtonTheme(ColorScheme colorScheme) =>
+      OutlinedButtonThemeData(
+        style: ButtonStyle(
+          foregroundColor: WidgetStateProperty.resolveWith(
+            (Set<WidgetState> states) => states.contains(WidgetState.disabled)
+                ? colorScheme.onSurface.withOpacity(0.4)
+                : colorScheme.primary,
+          ),
+          textStyle: WidgetStateProperty.all(
+            YataTypographyTokens.labelLarge.copyWith(color: colorScheme.primary),
+          ),
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(
+              horizontal: YataSpacingTokens.lg,
+              vertical: YataSpacingTokens.sm,
+            ),
+          ),
+          shape: WidgetStateProperty.all(
+            const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.medium)),
+            ),
+          ),
+          side: WidgetStateProperty.resolveWith(
+            (Set<WidgetState> states) => BorderSide(
+              color: states.contains(WidgetState.disabled)
+                  ? colorScheme.outlineVariant
+                  : colorScheme.primary,
+            ),
+          ),
+          overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+            if (states.contains(WidgetState.disabled)) {
+              return Colors.transparent;
+            }
+            final double opacity = states.contains(WidgetState.pressed) ? 0.1 : 0.05;
+            return colorScheme.primary.withOpacity(opacity);
+          }),
+        ),
+      );
 
   static TextButtonThemeData _buildTextButtonTheme(ColorScheme colorScheme) => TextButtonThemeData(
-      style: ButtonStyle(
-        foregroundColor: WidgetStateProperty.resolveWith(
-          (Set<WidgetState> states) => states.contains(WidgetState.disabled)
-              ? colorScheme.onSurface.withOpacity(0.4)
-              : colorScheme.primary,
-        ),
-        textStyle: WidgetStateProperty.all(
-          YataTypographyTokens.labelLarge.copyWith(color: colorScheme.primary),
-        ),
-        padding: WidgetStateProperty.all(
-          const EdgeInsets.symmetric(
-            horizontal: YataSpacingTokens.md,
-            vertical: YataSpacingTokens.xs,
-          ),
-        ),
-        overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-          if (states.contains(WidgetState.disabled)) {
-            return Colors.transparent;
-          }
-          final double opacity = states.contains(WidgetState.pressed) ? 0.1 : 0.05;
-          return colorScheme.primary.withOpacity(opacity);
-        }),
+    style: ButtonStyle(
+      foregroundColor: WidgetStateProperty.resolveWith(
+        (Set<WidgetState> states) => states.contains(WidgetState.disabled)
+            ? colorScheme.onSurface.withOpacity(0.4)
+            : colorScheme.primary,
       ),
-    );
+      textStyle: WidgetStateProperty.all(
+        YataTypographyTokens.labelLarge.copyWith(color: colorScheme.primary),
+      ),
+      padding: WidgetStateProperty.all(
+        const EdgeInsets.symmetric(
+          horizontal: YataSpacingTokens.md,
+          vertical: YataSpacingTokens.xs,
+        ),
+      ),
+      overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
+          return Colors.transparent;
+        }
+        final double opacity = states.contains(WidgetState.pressed) ? 0.1 : 0.05;
+        return colorScheme.primary.withOpacity(opacity);
+      }),
+    ),
+  );
 
   static InputDecorationTheme _buildInputDecorationTheme(ColorScheme colorScheme) {
     const BorderRadius inputRadius = BorderRadius.all(Radius.circular(YataRadiusTokens.medium));
@@ -271,106 +274,108 @@ class AppTheme {
     );
   }
 
-  static ChipThemeData _buildChipTheme(ColorScheme colorScheme, TextTheme textTheme) => ChipThemeData(
-      backgroundColor: colorScheme.surfaceContainerHighest,
-      disabledColor: colorScheme.surfaceContainerHighest.withOpacity(0.4),
-      selectedColor: colorScheme.primary.withOpacity(0.12),
-      secondarySelectedColor: colorScheme.primary.withOpacity(0.18),
-      padding: const EdgeInsets.symmetric(
-        horizontal: YataSpacingTokens.sm,
-        vertical: YataSpacingTokens.xs,
-      ),
-      shape: const StadiumBorder(),
-      labelStyle: textTheme.labelMedium,
-      secondaryLabelStyle: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
-      brightness: colorScheme.brightness,
-      side: BorderSide(color: colorScheme.outlineVariant),
-    );
+  static ChipThemeData _buildChipTheme(ColorScheme colorScheme, TextTheme textTheme) =>
+      ChipThemeData(
+        backgroundColor: colorScheme.surfaceContainerHighest,
+        disabledColor: colorScheme.surfaceContainerHighest.withOpacity(0.4),
+        selectedColor: colorScheme.primary.withOpacity(0.12),
+        secondarySelectedColor: colorScheme.primary.withOpacity(0.18),
+        padding: const EdgeInsets.symmetric(
+          horizontal: YataSpacingTokens.sm,
+          vertical: YataSpacingTokens.xs,
+        ),
+        shape: const StadiumBorder(),
+        labelStyle: textTheme.labelMedium,
+        secondaryLabelStyle: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
+        brightness: colorScheme.brightness,
+        side: BorderSide(color: colorScheme.outlineVariant),
+      );
 
   static CheckboxThemeData _buildCheckboxTheme(ColorScheme colorScheme) => CheckboxThemeData(
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.small)),
-      ),
-      side: BorderSide(color: colorScheme.outlineVariant),
-      fillColor: WidgetStateProperty.resolveWith(
-        (Set<WidgetState> states) =>
-            states.contains(WidgetState.selected) ? colorScheme.primary : colorScheme.surface,
-      ),
-      checkColor: WidgetStateProperty.all(colorScheme.onPrimary),
-    );
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.small)),
+    ),
+    side: BorderSide(color: colorScheme.outlineVariant),
+    fillColor: WidgetStateProperty.resolveWith(
+      (Set<WidgetState> states) =>
+          states.contains(WidgetState.selected) ? colorScheme.primary : colorScheme.surface,
+    ),
+    checkColor: WidgetStateProperty.all(colorScheme.onPrimary),
+  );
 
   static RadioThemeData _buildRadioTheme(ColorScheme colorScheme) => RadioThemeData(
-      fillColor: WidgetStateProperty.resolveWith(
-        (Set<WidgetState> states) => states.contains(WidgetState.selected)
-            ? colorScheme.primary
-            : colorScheme.outlineVariant,
-      ),
-    );
+    fillColor: WidgetStateProperty.resolveWith(
+      (Set<WidgetState> states) =>
+          states.contains(WidgetState.selected) ? colorScheme.primary : colorScheme.outlineVariant,
+    ),
+  );
 
   static SwitchThemeData _buildSwitchTheme(ColorScheme colorScheme) => SwitchThemeData(
-      thumbColor: WidgetStateProperty.resolveWith(
-        (Set<WidgetState> states) => states.contains(WidgetState.selected)
-            ? colorScheme.primary
-            : colorScheme.outlineVariant,
-      ),
-      trackColor: WidgetStateProperty.resolveWith(
-        (Set<WidgetState> states) => states.contains(WidgetState.selected)
-            ? colorScheme.primary.withOpacity(0.35)
-            : colorScheme.outlineVariant.withOpacity(0.5),
-      ),
-    );
+    thumbColor: WidgetStateProperty.resolveWith(
+      (Set<WidgetState> states) =>
+          states.contains(WidgetState.selected) ? colorScheme.primary : colorScheme.outlineVariant,
+    ),
+    trackColor: WidgetStateProperty.resolveWith(
+      (Set<WidgetState> states) => states.contains(WidgetState.selected)
+          ? colorScheme.primary.withOpacity(0.35)
+          : colorScheme.outlineVariant.withOpacity(0.5),
+    ),
+  );
 
-  static FloatingActionButtonThemeData _buildFabTheme(ColorScheme colorScheme) => FloatingActionButtonThemeData(
-      backgroundColor: colorScheme.primary,
-      foregroundColor: colorScheme.onPrimary,
-      elevation: 0,
-      hoverElevation: 0,
-      focusElevation: 0,
-      highlightElevation: 0,
-      disabledElevation: 0,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.large)),
-      ),
-      focusColor: colorScheme.primary.withOpacity(0.18),
-      splashColor: colorScheme.primary.withOpacity(0.2),
-      hoverColor: colorScheme.primary.withOpacity(0.12),
-      iconSize: 24,
-    );
+  static FloatingActionButtonThemeData _buildFabTheme(ColorScheme colorScheme) =>
+      FloatingActionButtonThemeData(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+        elevation: 0,
+        hoverElevation: 0,
+        focusElevation: 0,
+        highlightElevation: 0,
+        disabledElevation: 0,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.large)),
+        ),
+        focusColor: colorScheme.primary.withOpacity(0.18),
+        splashColor: colorScheme.primary.withOpacity(0.2),
+        hoverColor: colorScheme.primary.withOpacity(0.12),
+        iconSize: 24,
+      );
 
-  static DialogThemeData _buildDialogTheme(ColorScheme colorScheme, TextTheme textTheme) => DialogThemeData(
-      backgroundColor: colorScheme.surface,
-      surfaceTintColor: Colors.transparent,
-      shadowColor: YataElevationTokens.level4.first.color,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.large)),
-      ),
-      titleTextStyle: textTheme.headlineSmall?.copyWith(color: colorScheme.onSurface),
-      contentTextStyle: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
-    );
+  static DialogThemeData _buildDialogTheme(ColorScheme colorScheme, TextTheme textTheme) =>
+      DialogThemeData(
+        backgroundColor: colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: YataElevationTokens.level4.first.color,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.large)),
+        ),
+        titleTextStyle: textTheme.headlineSmall?.copyWith(color: colorScheme.onSurface),
+        contentTextStyle: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
+      );
 
-  static BottomSheetThemeData _buildBottomSheetTheme(ColorScheme colorScheme) => BottomSheetThemeData(
-      backgroundColor: colorScheme.surface,
-      surfaceTintColor: Colors.transparent,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(YataRadiusTokens.large)),
-      ),
-      showDragHandle: true,
-      dragHandleColor: colorScheme.outlineVariant,
-    );
+  static BottomSheetThemeData _buildBottomSheetTheme(ColorScheme colorScheme) =>
+      BottomSheetThemeData(
+        backgroundColor: colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(YataRadiusTokens.large)),
+        ),
+        showDragHandle: true,
+        dragHandleColor: colorScheme.outlineVariant,
+      );
 
   static ListTileThemeData _buildListTileTheme(ColorScheme colorScheme) => ListTileThemeData(
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.medium)),
-      ),
-      tileColor: colorScheme.surface,
-      iconColor: colorScheme.onSurfaceVariant,
-      textColor: colorScheme.onSurface,
-      dense: false,
-      contentPadding: const EdgeInsets.symmetric(
-        horizontal: YataSpacingTokens.md,
-        vertical: YataSpacingTokens.xs,
-      ),
-    );
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(YataRadiusTokens.medium)),
+    ),
+    tileColor: colorScheme.surface,
+    iconColor: colorScheme.onSurfaceVariant,
+    textColor: colorScheme.onSurface,
+    dense: false,
+    contentPadding: const EdgeInsets.symmetric(
+      horizontal: YataSpacingTokens.md,
+      vertical: YataSpacingTokens.xs,
+    ),
+  );
 
   static const ColorScheme _lightColorScheme = ColorScheme(
     brightness: Brightness.light,


### PR DESCRIPTION
概要
- 数量ステッパーの中央をタップするとインラインで編集できるように変更
- Enter/フォーカスアウトで確定（min/max クランプ、数字のみ）
- ESC で編集をキャンセル（元の値に戻す）
- compact/regular に応じて中央タップ領域・編集中幅を拡大
- 編集中に +/- を押すと、先に編集内容を確定してから増減

変更ファイル
- lib/shared/components/inputs/quantity_stepper.dart

動作確認
- 左ペイン/右ペインのステッパーで中央タップ→直接編集が可能
- Enter/フォーカスアウトで確定され、min/max 範囲にクランプされる
- ESC で編集キャンセルし、元の値に戻る
- 編集中に +/- を押すと、まず確定→増減
- compact/regular の双方でタップ領域が広がって押しやすい

設計メモ
- StatefulWidget 化し、_editing, TextEditingController, FocusNode を管理
- Shortcuts/Actions で ESC キャンセルをハンドリング
- didUpdateWidget で非編集中に外部から value が更新された場合に同期

影響範囲
- 既存の呼び出し側（onChanged/value/min/max/compact の API）は非変更
- ダイアログによる編集は撤廃（別ブランチで保持済み）

補足/フォローアップ（任意）
- 端末種別に応じて「長押しで数値入力ダイアログ」などの併用も検討余地あり
- 中央領域の幅は更に調整可能。実機での押しやすさに応じて微調整可